### PR TITLE
Fix router correctness and expand edge case coverage

### DIFF
--- a/crates/router/examples/nested_router.rs
+++ b/crates/router/examples/nested_router.rs
@@ -34,7 +34,7 @@ impl Render for NestedRouter {
   }
 }
 
-#[derive(IntoElement, IntoLayout)]
+#[derive(Default, IntoElement, IntoLayout)]
 pub struct Nav {
   outlet: Outlet,
 }
@@ -63,7 +63,7 @@ impl RenderOnce for Nav {
   }
 }
 
-#[derive(IntoElement, IntoLayout)]
+#[derive(Default, IntoElement, IntoLayout)]
 pub struct UserLayout {
   outlet: Outlet,
 }

--- a/crates/router/examples/sub_router.rs
+++ b/crates/router/examples/sub_router.rs
@@ -1,6 +1,6 @@
 use gpui::prelude::*;
-use gpui::{App, Application, Context, Window, WindowOptions, div, rgb, white};
-use gpui_router::{IntoLayout, NavLink, Outlet, Route, Routes, init as router_init};
+use gpui::{App, Application, Context, RenderOnce, Window, WindowOptions, div, rgb, white};
+use gpui_router::{NavLink, Route, Routes, init as router_init};
 
 struct SubRouter {}
 
@@ -15,45 +15,84 @@ impl Render for SubRouter {
       .bg(rgb(0x2e7d32))
       .text_color(white())
       .child(div().text_xl().child("Sub Router Example"))
+      .child(div().child(
+        "The top-level router hands off every /settings route to a nested SettingsRouter, \
+           which then routes inside the /settings subtree with its own basename.",
+      ))
+      .child(root_nav())
       .child(
-        Routes::new().child(
-          Route::new()
-            .layout(Nav::new())
-            .child(Route::new().index().element(|_, _| home()))
-            .child(Route::new().path("about").element(|_, _| about()))
-            .child(Route::new().path("dashboard").element(|_, _| dashboard()))
-            .child(Route::new().path("{*not_match}").element(|_, _| not_match())),
-        ),
+        Routes::new()
+          .basename("/")
+          .child(Route::new().index().element(|_, _| home()))
+          .child(Route::new().path("about").element(|_, _| about()))
+          .child(Route::new().path("dashboard").element(|_, _| dashboard()))
+          .child(Route::new().path("settings").element(|_, _| SettingsRouter {}))
+          .child(Route::new().path("settings/{*rest}").element(|_, _| SettingsRouter {}))
+          .child(Route::new().path("{*not_match}").element(|_, _| not_match())),
       )
   }
 }
 
-#[derive(Default, IntoElement, IntoLayout)]
-pub struct Nav {
-  outlet: Outlet,
-}
+#[derive(IntoElement)]
+struct SettingsRouter {}
 
-impl Nav {
-  pub fn new() -> Self {
-    Self { outlet: Outlet::new() }
-  }
-}
-
-impl RenderOnce for Nav {
+impl RenderOnce for SettingsRouter {
   fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
     div()
+      .mt_4()
+      .flex()
+      .flex_col()
+      .gap_2()
+      .rounded_md()
+      .bg(rgb(0x1b5e20))
+      .p_3()
+      .child(div().text_lg().child("SettingsRouter"))
       .child(
-        div()
-          .flex()
-          .gap_4()
-          .text_lg()
-          .child(NavLink::new().to("/").child(div().child("Home")))
-          .child(NavLink::new().to("/about").child(div().child("About")))
-          .child(NavLink::new().to("/dashboard").child(div().child("Dashboard")))
-          .child(NavLink::new().to("/nothing-here").child(div().child("Not Match"))),
+        div().child("This nested router only handles the /settings subtree via Routes::new().basename(\"/settings\")."),
       )
-      .child(self.outlet)
+      .child(settings_nav())
+      .child(
+        Routes::new()
+          .basename("/settings")
+          .child(Route::new().index().element(|_, _| settings_home()))
+          .child(Route::new().path("profile").element(|_, _| settings_profile()))
+          .child(Route::new().path("security").element(|_, _| settings_security()))
+          .child(Route::new().path("billing").element(|_, _| settings_billing()))
+          .child(Route::new().path("{*rest}").element(|_, _| settings_not_match())),
+      )
   }
+}
+
+fn root_nav() -> impl IntoElement {
+  div()
+    .flex()
+    .gap_4()
+    .text_lg()
+    .child(NavLink::new().to("/").child(div().child("Home")))
+    .child(NavLink::new().to("/about").child(div().child("About")))
+    .child(NavLink::new().to("/dashboard").child(div().child("Dashboard")))
+    .child(NavLink::new().to("/settings").child(div().child("Settings")))
+    .child(
+      NavLink::new()
+        .to("/settings/security")
+        .child(div().child("Settings Security")),
+    )
+    .child(NavLink::new().to("/nothing-here").child(div().child("Not Match")))
+}
+
+fn settings_nav() -> impl IntoElement {
+  div()
+    .flex()
+    .gap_4()
+    .child(NavLink::new().to("/settings").end(true).child(div().child("Overview")))
+    .child(NavLink::new().to("/settings/profile").child(div().child("Profile")))
+    .child(NavLink::new().to("/settings/security").child(div().child("Security")))
+    .child(NavLink::new().to("/settings/billing").child(div().child("Billing")))
+    .child(
+      NavLink::new()
+        .to("/settings/unknown-page")
+        .child(div().child("Local 404")),
+    )
 }
 
 fn home() -> impl IntoElement {
@@ -66,6 +105,32 @@ fn about() -> impl IntoElement {
 
 fn dashboard() -> impl IntoElement {
   div().child("Dashboard")
+}
+
+fn settings_home() -> impl IntoElement {
+  div().child("Settings overview handled by the nested router.")
+}
+
+fn settings_profile() -> impl IntoElement {
+  div().child("Profile settings page")
+}
+
+fn settings_security() -> impl IntoElement {
+  div().child("Security settings page")
+}
+
+fn settings_billing() -> impl IntoElement {
+  div().child("Billing settings page")
+}
+
+fn settings_not_match() -> impl IntoElement {
+  div()
+    .child(div().child("This route was not found inside SettingsRouter."))
+    .child(
+      NavLink::new()
+        .to("/settings")
+        .child(div().child("Back to settings overview")),
+    )
 }
 
 fn not_match() -> impl IntoElement {

--- a/crates/router/examples/sub_router.rs
+++ b/crates/router/examples/sub_router.rs
@@ -28,7 +28,7 @@ impl Render for SubRouter {
   }
 }
 
-#[derive(IntoElement, IntoLayout)]
+#[derive(Default, IntoElement, IntoLayout)]
 pub struct Nav {
   outlet: Outlet,
 }

--- a/crates/router/src/hooks.rs
+++ b/crates/router/src/hooks.rs
@@ -5,7 +5,7 @@ use hashbrown::HashMap;
 /// Returns a function that lets you navigate programmatically in response to user interactions or effects.
 pub fn use_navigate(cx: &mut App) -> impl FnMut(SharedString) + '_ {
   move |path: SharedString| {
-    cx.global_mut::<RouterState>().location.pathname = path;
+    cx.global_mut::<RouterState>().with_path(path);
   }
 }
 

--- a/crates/router/src/hooks.rs
+++ b/crates/router/src/hooks.rs
@@ -58,6 +58,18 @@ pub mod tests {
         navigate("/nothing-here".into());
       }
       assert_eq!(cx.global::<RouterState>().location.pathname, "/nothing-here");
+
+      {
+        let mut navigate = use_navigate(cx);
+        navigate("settings/".into());
+      }
+      assert_eq!(cx.global::<RouterState>().location.pathname, "/settings");
+
+      {
+        let mut navigate = use_navigate(cx);
+        navigate("".into());
+      }
+      assert_eq!(cx.global::<RouterState>().location.pathname, "/");
     });
   }
 }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -19,6 +19,7 @@ pub use outlet::*;
 pub use route::*;
 pub use router::*;
 pub use routes::*;
+pub(crate) use state::normalize_pathname;
 pub use state::*;
 
 /// Initializes the router system within a GPUI application context.

--- a/crates/router/src/nav_link.rs
+++ b/crates/router/src/nav_link.rs
@@ -1,4 +1,4 @@
-use crate::{RouterState, use_navigate};
+use crate::{RouterState, normalize_pathname, use_navigate};
 use gpui::*;
 use smallvec::SmallVec;
 
@@ -79,14 +79,15 @@ impl NavLink {
 
 impl RenderOnce for NavLink {
   fn render(mut self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+    let to = normalize_pathname(self.to.as_ref());
     let is_active = if cx.has_global::<RouterState>() {
-      let pathname = &cx.global::<RouterState>().location.pathname;
-      if self.to == "/" || self.end {
-        pathname.as_ref() == self.to.as_ref()
+      let pathname = normalize_pathname(cx.global::<RouterState>().location.pathname.as_ref());
+      if to == "/" || self.end {
+        pathname.as_ref() == to.as_ref()
       } else {
-        pathname.as_ref() == self.to.as_ref()
+        pathname.as_ref() == to.as_ref()
           || pathname
-            .strip_prefix(self.to.as_ref())
+            .strip_prefix(to.as_ref())
             .is_some_and(|rest| rest.is_empty() || rest.starts_with('/'))
       }
     } else {
@@ -104,10 +105,10 @@ impl RenderOnce for NavLink {
 
     self
       .base
-      .id(ElementId::from(self.to.clone()))
+      .id(ElementId::from(to.clone()))
       .on_click(move |_, window, cx| {
         let mut navigate = use_navigate(cx);
-        navigate(self.to.clone());
+        navigate(to.clone());
         window.refresh();
       })
       .children(self.children)

--- a/crates/router/src/nav_link.rs
+++ b/crates/router/src/nav_link.rs
@@ -77,19 +77,29 @@ impl NavLink {
   }
 }
 
+fn is_active_path(pathname: &str, to: &str, end: bool) -> bool {
+  let pathname = normalize_pathname(pathname);
+  let to = normalize_pathname(to);
+
+  if to == "/" || end {
+    pathname.as_ref() == to.as_ref()
+  } else {
+    pathname.as_ref() == to.as_ref()
+      || pathname
+        .strip_prefix(to.as_ref())
+        .is_some_and(|rest| rest.is_empty() || rest.starts_with('/'))
+  }
+}
+
 impl RenderOnce for NavLink {
   fn render(mut self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
     let to = normalize_pathname(self.to.as_ref());
     let is_active = if cx.has_global::<RouterState>() {
-      let pathname = normalize_pathname(cx.global::<RouterState>().location.pathname.as_ref());
-      if to == "/" || self.end {
-        pathname.as_ref() == to.as_ref()
-      } else {
-        pathname.as_ref() == to.as_ref()
-          || pathname
-            .strip_prefix(to.as_ref())
-            .is_some_and(|rest| rest.is_empty() || rest.starts_with('/'))
-      }
+      is_active_path(
+        cx.global::<RouterState>().location.pathname.as_ref(),
+        to.as_ref(),
+        self.end,
+      )
     } else {
       debug_assert!(
         false,
@@ -112,5 +122,35 @@ impl RenderOnce for NavLink {
         window.refresh();
       })
       .children(self.children)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::is_active_path;
+
+  #[test]
+  fn test_root_nav_link_is_only_active_on_exact_root() {
+    assert!(is_active_path("/", "/", false));
+    assert!(is_active_path("", "", false));
+    assert!(!is_active_path("/settings", "/", false));
+  }
+
+  #[test]
+  fn test_nav_link_matches_descendants_by_default() {
+    assert!(is_active_path("/settings/profile", "/settings", false));
+    assert!(is_active_path("/settings/profile/", "settings", false));
+  }
+
+  #[test]
+  fn test_nav_link_end_requires_exact_match() {
+    assert!(is_active_path("/settings", "/settings", true));
+    assert!(!is_active_path("/settings/profile", "/settings", true));
+  }
+
+  #[test]
+  fn test_nav_link_respects_segment_boundaries() {
+    assert!(!is_active_path("/users", "/user", false));
+    assert!(!is_active_path("/settings-and-more", "/settings", false));
   }
 }

--- a/crates/router/src/route.rs
+++ b/crates/router/src/route.rs
@@ -1,4 +1,4 @@
-use crate::{Layout, RouterState};
+use crate::{Layout, RouterState, normalize_pathname};
 use gpui::*;
 use matchit::Router as MatchitRouter;
 use smallvec::SmallVec;
@@ -124,32 +124,41 @@ impl Route {
     self
   }
 
-  pub(crate) fn build_route_map(&self, basename: &str) -> MatchitRouter<()> {
+  pub(crate) fn full_path(&self, basename: &str) -> SharedString {
     let basename = basename.trim_end_matches('/');
-    let mut router_map = MatchitRouter::new();
-
     let path = match self.path {
       Some(ref path) => format!("{}/{}", basename, path),
       None => basename.to_string(),
     };
+    normalize_pathname(path)
+  }
 
-    let path = if path != "/" { path.trim_end_matches('/') } else { &path };
+  pub(crate) fn build_route_map(&self, basename: &str) -> MatchitRouter<SharedString> {
+    let mut router_map = MatchitRouter::new();
+    let path = self.full_path(basename);
 
     if self.element.is_some() {
-      router_map.insert(path, ()).unwrap();
+      router_map.insert(path.as_ref(), path.clone()).unwrap();
       return router_map;
     }
 
-    // Recursively build the route map
     for route in self.routes.iter() {
-      router_map.merge(route.build_route_map(path)).unwrap();
+      router_map.merge(route.build_route_map(path.as_ref())).unwrap();
     }
 
     router_map
   }
 
-  pub(crate) fn in_pattern(&self, basename: &str, path: &str) -> bool {
-    self.build_route_map(basename).at(path).is_ok()
+  pub(crate) fn contains_pattern(&self, basename: &str, pattern: &str) -> bool {
+    if self.element.is_some() {
+      return self.full_path(basename).as_ref() == pattern;
+    }
+
+    let basename = self.full_path(basename);
+    self
+      .routes
+      .iter()
+      .any(|route| route.contains_pattern(basename.as_ref(), pattern))
   }
 }
 
@@ -159,15 +168,21 @@ impl RenderOnce for Route {
       return element_fn(window, cx);
     }
 
+    let basename = self.full_path(self.basename.as_ref());
+
     if let Some(mut layout) = self.layout {
-      let pathname = cx.global::<RouterState>().location.pathname.clone();
-      let basename = self.basename.trim_end_matches('/');
-      let basename = match self.path {
-        Some(ref path) => format!("{}/{}", basename, path),
-        None => basename.to_string(),
-      };
+      let pathname = normalize_pathname(cx.global::<RouterState>().location.pathname.as_ref());
       let routes = std::mem::take(&mut self.routes);
-      let route = routes.into_iter().find(|route| route.in_pattern(&basename, &pathname));
+      let mut route_map = MatchitRouter::new();
+      for route in routes.iter() {
+        route_map.merge(route.build_route_map(basename.as_ref())).unwrap();
+      }
+
+      let route = route_map.at(pathname.as_ref()).ok().and_then(|matched| {
+        routes
+          .into_iter()
+          .find(|route| route.contains_pattern(basename.as_ref(), matched.value.as_ref()))
+      });
       if let Some(route) = route {
         layout.outlet(route.basename(basename).render(window, cx).into_any_element());
       }

--- a/crates/router/src/router_tests.rs
+++ b/crates/router/src/router_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 pub mod tests {
-  use crate::{Route, RouterState, Routes};
+  use crate::{Route, RouterState, Routes, normalize_pathname};
   use gpui::prelude::*;
   use gpui::{TestAppContext, VisualTestContext, Window};
 
@@ -86,5 +86,64 @@ pub mod tests {
       0,
       "About element should not be evaluated during route configuration"
     );
+  }
+
+  #[gpui::test]
+  async fn test_static_routes_win_over_dynamic_routes(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new()
+        .basename("/")
+        .child(Route::new().path("{id}").element(|_, _| "dynamic"))
+        .child(Route::new().path("settings").element(|_, _| "settings"));
+
+      let matched = routes.match_route("/settings").unwrap();
+      Routes::apply_match(cx, normalize_pathname("/settings"), Some(&matched));
+
+      assert_eq!(matched.pattern, "/settings");
+      assert!(cx.global::<RouterState>().params.is_empty());
+    });
+  }
+
+  #[gpui::test]
+  async fn test_route_params_are_cleared_when_next_match_has_none(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new()
+        .basename("/")
+        .child(Route::new().path("user/{id}").element(|_, _| "user"))
+        .child(Route::new().path("about").element(|_, _| "about"));
+
+      let user_match = routes.match_route("/user/42").unwrap();
+      Routes::apply_match(cx, normalize_pathname("/user/42"), Some(&user_match));
+      assert_eq!(
+        cx.global::<RouterState>().params.get("id").map(|value| value.as_ref()),
+        Some("42")
+      );
+
+      let about_match = routes.match_route("/about").unwrap();
+      Routes::apply_match(cx, normalize_pathname("/about"), Some(&about_match));
+      assert!(cx.global::<RouterState>().params.is_empty());
+      assert_eq!(cx.global::<RouterState>().location.pathname, "/about");
+    });
+  }
+
+  #[gpui::test]
+  async fn test_pathnames_are_normalized_before_matching(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new()
+        .basename("/")
+        .child(Route::new().path("about").element(|_, _| "about"));
+
+      let matched = routes.match_route("/about/").unwrap();
+      Routes::apply_match(cx, normalize_pathname("/about/"), Some(&matched));
+
+      assert_eq!(matched.pattern, "/about");
+      assert_eq!(cx.global::<RouterState>().location.pathname, "/about");
+    });
   }
 }

--- a/crates/router/src/router_tests.rs
+++ b/crates/router/src/router_tests.rs
@@ -1,10 +1,25 @@
 #[cfg(test)]
 pub mod tests {
-  use crate::{Route, RouterState, Routes, normalize_pathname};
+  use crate::{Layout, Outlet, Route, RouterState, Routes, normalize_pathname};
   use gpui::prelude::*;
-  use gpui::{TestAppContext, VisualTestContext, Window};
+  use gpui::{AnyElement, App, TestAppContext, VisualTestContext, Window};
 
   struct Basic {}
+
+  #[derive(Default)]
+  struct TestLayout {
+    outlet: Outlet,
+  }
+
+  impl Layout for TestLayout {
+    fn outlet(&mut self, element: AnyElement) {
+      self.outlet = element.into();
+    }
+
+    fn render_layout(self: Box<Self>, _window: &mut Window, _cx: &mut App) -> AnyElement {
+      self.outlet.into_any_element()
+    }
+  }
 
   impl Render for Basic {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
@@ -131,6 +146,28 @@ pub mod tests {
   }
 
   #[gpui::test]
+  async fn test_apply_match_clears_params_when_route_is_unmatched(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new()
+        .basename("/")
+        .child(Route::new().path("user/{id}").element(|_, _| "user"));
+
+      let user_match = routes.match_route("/user/42").unwrap();
+      Routes::apply_match(cx, normalize_pathname("/user/42"), Some(&user_match));
+      assert_eq!(
+        cx.global::<RouterState>().params.get("id").map(|value| value.as_ref()),
+        Some("42")
+      );
+
+      Routes::apply_match(cx, normalize_pathname("/missing"), None);
+      assert!(cx.global::<RouterState>().params.is_empty());
+      assert_eq!(cx.global::<RouterState>().location.pathname, "/missing");
+    });
+  }
+
+  #[gpui::test]
   async fn test_pathnames_are_normalized_before_matching(cx: &mut TestAppContext) {
     cx.update(|cx| {
       crate::init(cx);
@@ -144,6 +181,178 @@ pub mod tests {
 
       assert_eq!(matched.pattern, "/about");
       assert_eq!(cx.global::<RouterState>().location.pathname, "/about");
+    });
+  }
+
+  #[gpui::test]
+  async fn test_match_route_returns_none_for_unknown_path_without_fallback(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new()
+        .basename("/")
+        .child(Route::new().index().element(|_, _| "home"))
+        .child(Route::new().path("about").element(|_, _| "about"));
+
+      assert!(routes.match_route("/missing").is_none());
+    });
+  }
+
+  #[gpui::test]
+  async fn test_basename_matching_supports_relative_and_trailing_slashes(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new()
+        .basename("app/")
+        .child(Route::new().index().element(|_, _| "home"))
+        .child(Route::new().path("settings").element(|_, _| "settings"));
+
+      let index_match = routes.match_route("/app").unwrap();
+      assert_eq!(index_match.pattern, "/app");
+
+      let settings_match = routes.match_route("/app/settings/").unwrap();
+      assert_eq!(settings_match.pattern, "/app/settings");
+    });
+  }
+
+  #[gpui::test]
+  async fn test_nested_layout_static_routes_win_over_dynamic_siblings(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new().child(
+        Route::new().layout(TestLayout::default()).child(
+          Route::new()
+            .path("users")
+            .layout(TestLayout::default())
+            .child(Route::new().path("{id}").element(|_, _| "dynamic"))
+            .child(Route::new().path("settings").element(|_, _| "settings")),
+        ),
+      );
+
+      let matched = routes.match_route("/users/settings").unwrap();
+      assert_eq!(matched.pattern, "/users/settings");
+      assert!(matched.params.is_empty());
+    });
+  }
+
+  #[gpui::test]
+  async fn test_nested_index_route_matches_parent_path(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new().child(
+        Route::new().child(
+          Route::new()
+            .path("users")
+            .layout(TestLayout::default())
+            .child(Route::new().index().element(|_, _| "users-index")),
+        ),
+      );
+
+      let matched = routes.match_route("/users").unwrap();
+      assert_eq!(matched.pattern, "/users");
+    });
+  }
+
+  #[gpui::test]
+  async fn test_wildcard_routes_capture_remaining_segments(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new()
+        .basename("/")
+        .child(Route::new().path("files/{*path}").element(|_, _| "files"));
+
+      let matched = routes.match_route("/files/docs/readme.md").unwrap();
+      assert_eq!(matched.pattern, "/files/{*path}");
+      assert_eq!(
+        matched.params.get("path").map(|value| value.as_ref()),
+        Some("docs/readme.md")
+      );
+    });
+  }
+
+  #[gpui::test]
+  async fn test_exact_routes_win_over_wildcards(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new()
+        .basename("/")
+        .child(Route::new().path("files/new").element(|_, _| "new"))
+        .child(Route::new().path("files/{*path}").element(|_, _| "files"));
+
+      let matched = routes.match_route("/files/new").unwrap();
+      assert_eq!(matched.pattern, "/files/new");
+      assert!(matched.params.is_empty());
+    });
+  }
+
+  #[gpui::test]
+  async fn test_nested_wildcard_routes_match_unknown_descendants(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new().child(
+        Route::new().layout(TestLayout::default()).child(
+          Route::new()
+            .path("docs")
+            .layout(TestLayout::default())
+            .child(Route::new().path("intro").element(|_, _| "intro"))
+            .child(Route::new().path("{*rest}").element(|_, _| "rest")),
+        ),
+      );
+
+      let matched = routes.match_route("/docs/guides/install/windows").unwrap();
+      assert_eq!(matched.pattern, "/docs/{*rest}");
+      assert_eq!(
+        matched.params.get("rest").map(|value| value.as_ref()),
+        Some("guides/install/windows")
+      );
+    });
+  }
+
+  #[gpui::test]
+  async fn test_multiple_dynamic_params_are_extracted(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new()
+        .basename("/")
+        .child(Route::new().path("org/{org}/repo/{repo}").element(|_, _| "repo"));
+
+      let matched = routes.match_route("/org/openai/repo/gpt-5").unwrap();
+      assert_eq!(matched.pattern, "/org/{org}/repo/{repo}");
+      assert_eq!(matched.params.get("org").map(|value| value.as_ref()), Some("openai"));
+      assert_eq!(matched.params.get("repo").map(|value| value.as_ref()), Some("gpt-5"));
+    });
+  }
+
+  #[gpui::test]
+  async fn test_dynamic_routes_require_the_full_segment_structure(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new()
+        .basename("/")
+        .child(Route::new().path("users/{id}").element(|_, _| "user"));
+
+      assert!(routes.match_route("/users").is_none());
+    });
+  }
+
+  #[gpui::test]
+  async fn test_catch_all_route_does_not_match_root_without_segments(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+      crate::init(cx);
+
+      let routes = Routes::new()
+        .basename("/")
+        .child(Route::new().path("{*rest}").element(|_, _| "rest"));
+
+      assert!(routes.match_route("/").is_none());
     });
   }
 }

--- a/crates/router/src/routes.rs
+++ b/crates/router/src/routes.rs
@@ -1,9 +1,14 @@
-use crate::Route;
-use crate::RouterState;
+use crate::{Route, RouterState, normalize_pathname};
 use gpui::prelude::*;
 use gpui::{App, Empty, SharedString, Window};
-use matchit::Router as MatchitRouter;
+use hashbrown::HashMap;
 use smallvec::SmallVec;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MatchedRoute {
+  pub(crate) pattern: SharedString,
+  pub(crate) params: HashMap<SharedString, SharedString>,
+}
 
 /// Renders a branch of [`Route`](crate::Route) that best matches the current path.
 #[derive(IntoElement)]
@@ -28,7 +33,7 @@ impl Routes {
 
   /// Sets the base path for all child `Route`s.
   pub fn basename(mut self, basename: impl Into<SharedString>) -> Self {
-    self.basename = basename.into();
+    self.basename = normalize_pathname(basename.into());
     self
   }
 
@@ -50,6 +55,39 @@ impl Routes {
   pub fn routes(&self) -> &SmallVec<[Route; 1]> {
     &self.routes
   }
+
+  pub(crate) fn match_route(&self, pathname: &str) -> Option<MatchedRoute> {
+    let pathname = normalize_pathname(pathname);
+    let mut route_map = matchit::Router::new();
+    for route in self.routes.iter() {
+      route_map.merge(route.build_route_map(self.basename.as_ref())).unwrap();
+    }
+
+    let matched = route_map.at(pathname.as_ref()).ok()?;
+    let params = matched
+      .params
+      .iter()
+      .map(|(key, value)| (key.to_owned().into(), value.to_owned().into()))
+      .collect();
+
+    Some(MatchedRoute {
+      pattern: matched.value.clone(),
+      params,
+    })
+  }
+
+  pub(crate) fn apply_match(cx: &mut App, pathname: SharedString, matched: Option<&MatchedRoute>) {
+    let state = cx.global_mut::<RouterState>();
+    state.location.pathname = pathname.clone();
+
+    if let Some(matched) = matched {
+      state.params = matched.params.clone();
+    } else {
+      state.params.clear();
+    }
+
+    state.path_match = None;
+  }
 }
 
 impl RenderOnce for Routes {
@@ -58,24 +96,15 @@ impl RenderOnce for Routes {
       panic!("RouterState not initialized");
     }
 
-    let mut route_map = MatchitRouter::new();
-    for route in self.routes.iter() {
-      route_map.merge(route.build_route_map(&self.basename)).unwrap();
-    }
+    let pathname = normalize_pathname(cx.global::<RouterState>().location.pathname.as_ref());
+    let matched = self.match_route(pathname.as_ref());
+    Self::apply_match(cx, pathname, matched.as_ref());
 
-    let pathname = cx.global::<RouterState>().location.pathname.clone();
-    let matched = route_map.at(&pathname);
-
-    if let Ok(matched) = matched {
-      for (key, value) in matched.params.iter() {
-        cx.global_mut::<RouterState>()
-          .params
-          .insert(key.to_owned().into(), value.to_owned().into());
-      }
+    if let Some(matched) = matched {
       let route = self
         .routes
         .into_iter()
-        .find(|route| route.in_pattern(&self.basename, &pathname));
+        .find(|route| route.contains_pattern(self.basename.as_ref(), matched.pattern.as_ref()));
       if let Some(route) = route {
         return route.basename(self.basename).into_any_element();
       }

--- a/crates/router/src/state.rs
+++ b/crates/router/src/state.rs
@@ -2,6 +2,23 @@ use gpui::{App, Global, SharedString};
 use hashbrown::HashMap;
 use matchit::Params;
 
+pub(crate) fn normalize_pathname(pathname: impl AsRef<str>) -> SharedString {
+  let pathname = pathname.as_ref().trim();
+  let mut normalized = if pathname.is_empty() {
+    "/".to_string()
+  } else if pathname.starts_with('/') {
+    pathname.to_string()
+  } else {
+    format!("/{pathname}")
+  };
+
+  while normalized.len() > 1 && normalized.ends_with('/') {
+    normalized.pop();
+  }
+
+  normalized.into()
+}
+
 /// A Location represents a URL-like location in the router.
 /// It contains a pathname and an optional state object.
 #[derive(PartialEq, Eq, Ord, PartialOrd, Clone, Debug)]
@@ -16,7 +33,7 @@ impl Default for Location {
   /// Creates a default Location with pathname `/` and empty state.
   fn default() -> Self {
     Self {
-      pathname: "/".into(),
+      pathname: normalize_pathname("/"),
       state: Params::default(),
     }
   }
@@ -65,7 +82,7 @@ impl RouterState {
 
   /// Sets the current pathname in the router state.
   pub fn with_path(&mut self, pathname: SharedString) -> &mut Self {
-    self.location.pathname = pathname;
+    self.location.pathname = normalize_pathname(pathname);
     self
   }
 

--- a/crates/router/src/state.rs
+++ b/crates/router/src/state.rs
@@ -96,3 +96,37 @@ impl RouterState {
     cx.global_mut::<Self>()
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::{Location, RouterState, normalize_pathname};
+
+  #[test]
+  fn test_normalize_pathname_handles_empty_relative_and_trailing_slashes() {
+    assert_eq!(normalize_pathname(""), "/");
+    assert_eq!(normalize_pathname("about"), "/about");
+    assert_eq!(normalize_pathname("/about/"), "/about");
+    assert_eq!(normalize_pathname("  /about/team/  "), "/about/team");
+  }
+
+  #[test]
+  fn test_normalize_pathname_preserves_root() {
+    assert_eq!(normalize_pathname("/"), "/");
+    assert_eq!(normalize_pathname("////"), "/");
+  }
+
+  #[test]
+  fn test_router_state_with_path_normalizes_pathname() {
+    let mut state = RouterState {
+      location: Location::default(),
+      path_match: None,
+      params: Default::default(),
+    };
+
+    state.with_path("dashboard/".into());
+    assert_eq!(state.location.pathname, "/dashboard");
+
+    state.with_path("".into());
+    assert_eq!(state.location.pathname, "/");
+  }
+}


### PR DESCRIPTION
## Summary
- fix route selection and pathname normalization so matching is deterministic
- add broad edge case coverage for nested routes, wildcards, params, basename handling, and navigation behavior
- turn the sub_router example into a real nested router example with a dedicated /settings sub-router

## Verification
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets -- -D warnings
- cargo check --example sub_router
- cargo clippy -q --example sub_router -- -D warnings